### PR TITLE
Refactor: Include URL in mirrorlist download error message

### DIFF
--- a/src/arch.c
+++ b/src/arch.c
@@ -319,7 +319,7 @@ void mirrors_update(mirror_s* mirrors, const int progress, const unsigned ndownl
 
 char* mirror_loading(const char* fname, const unsigned tos){
 	char* buf = fname ? load_file(fname, 1) :  www_download_retry(MIRROR_LIST_URL, 0, tos, DOWNLOAD_RETRY, DOWNLOAD_WAIT, NULL, NULL);
-	if( !buf ) die("unable to load mirrorlist");
+	if( !buf ) die("unable to load mirrorlist from %s", MIRROR_LIST_URL);
 	buf = mem_nullterm(buf);
 	return buf;
 }


### PR DESCRIPTION
This commit enhances the error reporting when downloading the initial mirrorlist. If the download fails, the error message will now include the full URL that was being fetched.

This addresses part of an issue requesting more detailed debugging information in error messages. Other requested logging for DB file downloads and speed test package downloads were found to be already in place.