### PR TITLE
Zstandard improvement

### DIFF
--- a/include/gm/arch.h
+++ b/include/gm/arch.h
@@ -19,6 +19,8 @@
 #define ERROR_TAR_BLOCKEND  0x05
 #define ERROR_TAR_NOBLOCK   0x06
 #define ERROR_TAR_KV_ASSIGN 0x07
+#define ERROR_ZSTD_DATA     0x08
+#define ERROR_ZSTD          0x09
 
 
 //TODO pacman mirrorlist is not a default path need to parse pacman config and get the include directory for each db

--- a/include/gm/archive.h
+++ b/include/gm/archive.h
@@ -22,6 +22,7 @@ typedef struct tar_s{
 }tar_s;
 
 void* gzip_decompress(void* data);
+void* zstd_decompress(void* data);
 
 void tar_mopen(tar_s* tar, void* data);
 tarent_s* tar_next(tar_s* tar);

--- a/meson.build
+++ b/meson.build
@@ -163,6 +163,7 @@ libDeps  = [ cc.find_library('m', required : true) ] # math
 libDeps += [ dependency('libcurl', required: true) ]
 libDeps += [ dependency('zlib', required: true) ]
 libDeps += [ dependency('libsystemd', required: true) ]
+libDeps += [ dependency('libzstd', required: true) ]
 
 #########################
 # software dependencies #

--- a/src/arch.c
+++ b/src/arch.c
@@ -209,13 +209,13 @@ __private void* get_tar_zst(mirror_s* mirror, const char* repo, const unsigned t
     if( mirror->url[0] == '/' ){ // Handling for local file paths (e.g., /path/to/repo)
         // Assuming 'repo' is the direct name of the .db file, or part of path
         // This part might need review if local file structure is different from URL structure
-        __free char* url = str_printf("%s/%s.db", mirror->url, repo); 
+        __free char* url = str_printf("%s/%s.db.tar.zst", mirror->url, repo); 
         return load_file(url, 1);
     }
     else{
-        // Construct URL: <mirror->url_with_trailing_slash><architecture>/<repo_name>/<repo_name>.db
-        // Example: https://geo-mirror.cachyos.org/x86_64/cachyos/cachyos.db
-        __free char* url = str_printf("%s/%s/%s/%s.db", mirror->url, mirror->arch, repo, repo);
+        // Construct URL: <mirror->url_with_trailing_slash><architecture>/<repo_name>/<repo_name>.db.tar.zst
+        // Example: https://geo-mirror.cachyos.org/x86_64/cachyos/cachyos.db.tar.zst
+        __free char* url = str_printf("%s/%s/%s/%s.db.tar.zst", mirror->url, mirror->arch, repo, repo);
         void* ret = NULL;
         if( !mirror->wwwerror ){
             ret = www_download_retry(url, 0, tos, DOWNLOAD_RETRY, DOWNLOAD_WAIT, &mirror->proxy, &mirror->retry);
@@ -252,22 +252,25 @@ __private void mirror_update(mirror_s* mirror, const unsigned tos){
 			return;
 		}
 	
-		__free void* tarbuf = gzip_decompress(tarzstd);
+		__free void* tarbuf = zstd_decompress(tarzstd);
 		if( !tarbuf ){
-			dbg_error("decompress zstd archive from mirror: %s", mirror->url);
+			dbg_error("decompress zstd archive failed for mirror: %s", mirror->url);
 			mirror->status = MIRROR_ERR;
 			switch( errno ){
-				case EBADMSG:
-					mirror->error  = ERROR_GZIP_DATA;
+				case EBADMSG: // ZSTD_error_data_error often results in EBADMSG
+					mirror->error  = ERROR_ZSTD_DATA;
 				break;
 				default:
-					mirror->error  = ERROR_GZIP;
+					mirror->error  = ERROR_ZSTD;
 				break;
 			}
 			return;
 		}
 		
 		if( !(mirror->repo[ir].db = generate_db(tarbuf)) ){
+			// ERROR_TAR_NOBLOCK, ERROR_TAR_BLOCKEND etc are presumably defined elsewhere
+			// and are relevant to tar extraction, not zstd decompression itself.
+			// This block seems correct as is for tar errors.
 			switch( errno ){
 				case ENOENT : mirror->error = ERROR_TAR_NOBLOCK; break;
 				case EBADF  : mirror->error = ERROR_TAR_BLOCKEND; break;  

--- a/src/archive.c
+++ b/src/archive.c
@@ -5,45 +5,136 @@
 
 #include <archive.h>
 #include <zlib.h>
+#include <zstd.h>
 
 void* gzip_decompress(void* data) {
 	z_stream strm;
 	memset(&strm, 0, sizeof(strm));
 	if( inflateInit2(&strm, 16 + MAX_WBITS) != Z_OK ) die("Unable to initialize zlib");
 	size_t datasize = mem_header(data)->len;
-	size_t framesize = datasize * 2;
+	size_t framesize = datasize * 2; // Initial estimate
 	void* dec = MANY(char, framesize);
+	mem_header(dec)->len = 0; // Initialize current decompressed size
 	
 	strm.avail_in  = datasize;
 	strm.next_in   = (Bytef*)data;
-	strm.avail_out = framesize;
-	strm.next_out  = (Bytef*)dec;
 	
 	int ret;
 	do{
-		if( (ret=inflate(&strm, Z_NO_FLUSH)) != Z_OK && ret != Z_STREAM_END ){
+		// Prepare output buffer for this iteration
+		strm.avail_out = mem_available(dec);
+		strm.next_out  = (Bytef*)mem_addressing(dec, mem_header(dec)->len);
+
+		ret = inflate(&strm, Z_NO_FLUSH);
+		
+		// Update how much was decompressed in this iteration
+		size_t decompressed_this_iteration = mem_available(dec) - strm.avail_out;
+		mem_header(dec)->len += decompressed_this_iteration;
+
+		if( ret != Z_OK && ret != Z_STREAM_END ){
 			switch( ret ){
 				case Z_DATA_ERROR:
 					errno = EBADMSG;
 				break;
 				default:
-					errno = EINVAL;
+					errno = EINVAL; // Generic error
 				break;
 			}
 			mem_free(dec);
-			dbg_error("decompression failed %d: %s", ret, zError(ret));
+			dbg_error("gzip decompression failed %d: %s", ret, zError(ret));
 			return NULL;
 		}
-		mem_header(dec)->len += framesize - strm.avail_out;
-		if (strm.avail_out == 0) {
-			dec = mem_upsize(dec, framesize);
-			framesize = mem_available(dec);
-			strm.avail_out = framesize;
+		
+		if (strm.avail_out == 0 && ret != Z_STREAM_END) { // Output buffer full, need to resize
+			// Double the current capacity, or add a significant chunk
+			size_t current_capacity = mem_header(dec)->len + mem_available(dec);
+			size_t new_capacity = current_capacity * 2; 
+			// Ensure new_capacity is larger, especially if current_capacity was 0 (though MANY should prevent this)
+			if (new_capacity <= current_capacity) new_capacity = current_capacity + framesize;
+
+
+			dec = mem_upsize(dec, new_capacity - current_capacity); // mem_upsize adds to current_capacity
+			// framesize here is just a chunk size hint for upsize, could be ZSTD_DStreamOutSize() too
 		}
-		strm.next_out  = (Bytef*)(mem_addressing(dec, mem_header(dec)->len));
 	}while( ret != Z_STREAM_END );
 	
 	inflateEnd(&strm);
+	return dec;
+}
+
+void* zstd_decompress(void* data) {
+	ZSTD_DStream* dstream = ZSTD_createDStream();
+	if (!dstream) {
+		errno = ENOMEM; // Or some other appropriate error
+		dbg_error("Failed to create ZSTD_DStream");
+		return NULL;
+	}
+
+	size_t init_ret = ZSTD_initDStream(dstream);
+	if (ZSTD_isError(init_ret)) {
+		ZSTD_freeDStream(dstream);
+		errno = EINVAL; // Or map ZSTD error code
+		dbg_error("ZSTD_initDStream error: %s", ZSTD_getErrorName(init_ret));
+		return NULL;
+	}
+
+	size_t datasize = mem_header(data)->len;
+	ZSTD_inBuffer input = { data, datasize, 0 };
+
+	// Initial output buffer size
+	// Using ZSTD_DStreamOutSize() as recommended for streaming.
+	size_t out_buffer_size = ZSTD_DStreamOutSize();
+	void* dec = MANY(char, out_buffer_size);
+	if (!dec) { // Should not happen if MANY dies on error, but good practice
+		ZSTD_freeDStream(dstream);
+		errno = ENOMEM;
+		dbg_error("Failed to allocate initial memory for ZSTD decompression");
+		return NULL;
+	}
+	mem_header(dec)->len = 0; // No data decompressed yet
+
+	size_t zstd_ret;
+	do {
+		ZSTD_outBuffer output = { mem_addressing(dec, mem_header(dec)->len), mem_available(dec), 0 };
+
+		zstd_ret = ZSTD_decompressStream(dstream, &output, &input);
+
+		if (ZSTD_isError(zstd_ret)) {
+			ZSTD_freeDStream(dstream);
+			mem_free(dec);
+			// Map ZSTD error codes to errno more specifically if possible
+			if (ZSTD_getErrorCode(zstd_ret) == ZSTD_error_prefix_unknown) {
+				errno = EBADMSG; // Data error seems appropriate
+			} else {
+				errno = EINVAL; // Generic error for other ZSTD issues
+			}
+			dbg_error("ZSTD_decompressStream error: %s", ZSTD_getErrorName(zstd_ret));
+			return NULL;
+		}
+
+		mem_header(dec)->len += output.pos;
+
+		// If output buffer is full and ZSTD_decompressStream hints there might be more data (ret > 0),
+		// or if not all input is consumed yet.
+		if (output.pos == output.size && (zstd_ret > 0 || input.pos < input.size)) {
+			// Upsize the buffer. Add another ZSTD_DStreamOutSize() chunk.
+			// mem_upsize expects the additional size, not the new total size.
+			dec = mem_upsize(dec, ZSTD_DStreamOutSize()); 
+			if (!dec) { // Should not happen if mem_upsize dies on error
+				ZSTD_freeDStream(dstream);
+				// Original dec was freed by mem_upsize on failure, if it works that way,
+				// otherwise, we might need to free it here. Assuming mem_upsize handles it.
+				errno = ENOMEM;
+				dbg_error("Failed to upsize memory for ZSTD decompression");
+				return NULL; // Critical error
+			}
+		}
+	} while (zstd_ret > 0 || input.pos < input.size); 
+	// Loop continues if ZSTD_decompressStream returns > 0 (meaning more frames to decompress or data to flush)
+	// or if there's still input data that hasn't been processed.
+	// Loop terminates when ZSTD_decompressStream returns 0 (all input consumed and flushed).
+
+	ZSTD_freeDStream(dstream);
 	return dec;
 }
 
@@ -270,20 +361,3 @@ void tar_close(tar_s* tar){
 int tar_errno(tar_s* tar){
 	return tar->err;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/investigation.c
+++ b/src/investigation.c
@@ -57,6 +57,8 @@ __private void investigate_mirror(mirror_s* mirror, mirror_s* local, unsigned mo
 			case ERROR_TAR_BLOCKEND : puts("  error: tar aspected end block but not finding, probably connection interrupt download or corrupted file"); break;
 			case ERROR_TAR_CHECKSUM : puts("  error: fail tar checksum, probably corrupted file"); break;
 			case ERROR_TAR_KV_ASSIGN: puts("  error: fail tar pax kv, probably corrupted file"); break;
+			case ERROR_ZSTD_DATA    : puts("  error: Zstandard data error (corrupted archive?)"); break;
+			case ERROR_ZSTD         : puts("  error: Zstandard decompression error"); break;
 			default: die("internal error, unmanaged %u error, please report this", mirror->error); break;
 		}
 		


### PR DESCRIPTION
Hi there! I've made some improvements to how we handle Zstandard compressed mirror databases.

Previously, you might have noticed the application struggling with many mirrors because of decompression errors. This was happening for a few reasons:
1. It was trying to use gzip decompression on Zstandard compressed database files.
2. It was asking for database files with a `.db` extension instead of the full `.db.tar.zst`. While some servers might be okay with this, it's not the standard way.
3. The initial way I handled Zstandard decompression would sometimes fail if the space I allocated for the output was too small.

I've addressed these issues by:
- Adding a more robust way to decompress Zstandard files that can adjust the amount of space needed on the fly. This should prevent those "Destination buffer is too small" errors.
- Updating how I handle downloaded mirror database files to use this new Zstandard decompression method.
- Changing how I request files so I'm now asking for the full `<repo_name>.db.tar.zst` names.
- Adding some new error codes to help identify Zstandard-specific issues more clearly.
- Making sure the messages you see for these new Zstandard errors are easy to understand.
- Ensuring all the necessary components for Zstandard are correctly included and linked.
- I also made some small improvements to how I handle gzip decompression for consistency.

With these changes, the application should now be able to successfully download, decompress, and understand Zstandard-compressed repository databases from places like CachyOS mirrors. This should make things much more reliable and allow you to work with a wider range of mirrors.