### PR TITLE
Fix: Improve speed calculation and add verbose logging for mirror tests

### DIFF
--- a/src/arch.c
+++ b/src/arch.c
@@ -581,15 +581,18 @@ __private void mirror_speed(mirror_s* mirror, const char* arch, unsigned type){
         strcpy(find.name, testname[i]);
 
         // mirror->repo[0].db refers to the 'cachyos' repository database
+        dbg_info("Speed test [%s]: Searching for package '%s'", mirror->url, testname[i]);
         pkgdesc_s* pk = mem_bsearch(mirror->repo[0].db, &find, pkgname_cmp); 
         if( !pk ){
-            dbg_warning("Speed test package '%s' not found in repository '%s' for mirror %s", testname[i], REPO[0], mirror->url);
+            dbg_warning("Speed test [%s]: Package '%s' NOT FOUND in its database (repo '%s').", mirror->url, testname[i], REPO[0]);
             continue; // Skip this package if not found, try next
         }
+        dbg_info("Speed test [%s]: Found package '%s', filename '%s'", mirror->url, testname[i], pk->filename);
 
         // Construct URL: <mirror->url_with_trailing_slash><architecture>/<repo_name_dir>/<package_filename>
         // Example: https://geo-mirror.cachyos.org/x86_64/cachyos/yay-12.3.5-1-x86_64.pkg.tar.zst
         __free char* url = str_printf("%s/%s/cachyos/%s", mirror->url, arch, pk->filename);
+        dbg_info("Speed test [%s]: Attempting to download test package '%s' from URL: %s", mirror->url, testname[i], url);
         unsigned retry = DOWNLOAD_RETRY;
         delay_t retrytime = DOWNLOAD_WAIT;
         
@@ -598,6 +601,13 @@ __private void mirror_speed(mirror_s* mirror, const char* arch, unsigned type){
             double start = time_sec();
             buf = www_download(url, 0, 0, NULL); // Assuming www_download handles freeing its internal buffers if retrying
             double stop  = time_sec();
+
+            if (buf) {
+                dbg_info("Speed test [%s]: Download attempt #%u for '%s' SUCCEEDED. Size: %u bytes. Start: %.9f, Stop: %.9f", mirror->url, DOWNLOAD_RETRY - retry, url, mem_header(buf)->len, start, stop);
+            } else {
+                dbg_info("Speed test [%s]: Download attempt #%u for '%s' FAILED (buf is NULL). Retries left: %u", mirror->url, DOWNLOAD_RETRY - retry, url, retry);
+            }
+
             if( !buf ){
                 ++mirror->retry; // This increments total retries for the mirror, might be too broad here
                 dbg_warning("Failed to download speed test package %s (attempt %u)", url, DOWNLOAD_RETRY - retry);
@@ -605,13 +615,24 @@ __private void mirror_speed(mirror_s* mirror, const char* arch, unsigned type){
                     delay_ms(retrytime);
                     retrytime *= 2;
                 }
-            } else {
+            } else { // This 'else' means buf is not NULL, so download was successful
                 unsigned size = mem_header(buf)->len;
-                if (stop > start) { // Avoid division by zero or negative time
-                     mirror->speed += (size / (1024.0*1024.0)) / (stop-start);
+                double time_delta = stop - start;
+
+                if (time_delta > 0) {
+                     mirror->speed += (size / (1024.0*1024.0)) / time_delta;
+                     successful_downloads++;
+                } else if (size > 0) { 
+                     // Download succeeded (buf is not NULL), size is positive, but time_delta is <= 0.
+                     // This can happen with very fast downloads and/or low timer resolution.
+                     dbg_warning("Speed test for %s downloaded %u bytes but time_delta is %.9f (start: %.9f, stop: %.9f). Assuming very high speed by using a minimal time delta.", url, size, time_delta, start, stop);
+                     double min_effective_time = 0.000001; // 1 microsecond
+                     mirror->speed += (size / (1024.0*1024.0)) / min_effective_time;
                      successful_downloads++;
                 } else {
-                     dbg_warning("Speed test download for %s resulted in invalid time.", url);
+                    // This case (size is 0 for a successful download) should be rare.
+                    dbg_warning("Speed test for %s successfully downloaded 0 bytes. Not counted in speed average.", url);
+                    // Do not increment successful_downloads here as 0 byte file gives no speed info.
                 }
                 mem_free(buf); // Free downloaded buffer
                 break; // Success, exit retry loop
@@ -624,9 +645,10 @@ __private void mirror_speed(mirror_s* mirror, const char* arch, unsigned type){
 
     if (successful_downloads > 0) {
         mirror->speed /= successful_downloads; // Average speed over successfully downloaded packages
+        dbg_info("Speed test [%s]: Final average speed: %.2f MB/s over %u successful downloads", mirror->url, mirror->speed, successful_downloads);
     } else {
         mirror->speed = 0.0; // Set to 0 if no packages could be downloaded for speed test
-        dbg_warning("No packages successfully downloaded for speed test for mirror %s", mirror->url);
+        dbg_warning("Speed test [%s]: No packages successfully downloaded or all had issues. Final speed set to 0.0.", mirror->url);
     }
 }
 


### PR DESCRIPTION
Refactor the speed calculation in `mirror_speed` within `src/arch.c`:
- For successful test package downloads where the measured time delta is zero or negative (e.g., due to very fast downloads or timer precision limits), I'll assign a very high speed based on a minimal 1-microsecond effective download time. This prevents these fast downloads from being incorrectly averaged as zero speed.
- I've added a `dbg_warning` to indicate when this very high speed assignment occurs.
- I've ensured that zero-byte successful downloads do not contribute to the speed average.

Enhance logging within the `mirror_speed` function:
- I've added `dbg_info` and `dbg_warning` statements to trace:
    - Search attempts for each test package.
    - Confirmation when test packages are found (including filename) or not found.
    - The exact URL constructed for each test package download.
    - The result of each download attempt (success/failure, size, timing, retry count) within the download loop.
- I've improved the final warning message if no packages contribute to the speed average for a mirror.

These changes aim to provide more accurate speed assessments for fast mirrors and offer better diagnostics for the speed testing process.